### PR TITLE
Fix for FNF chords showing as split notes in the path notation.

### DIFF
--- a/src/sightread/songparts.cpp
+++ b/src/sightread/songparts.cpp
@@ -149,8 +149,7 @@ void SightRead::NoteTrack::compute_base_score_ticks()
 
 void SightRead::NoteTrack::merge_same_time_notes()
 {
-    if (m_track_type == TrackType::Drums
-        || m_track_type == TrackType::FortniteFestival) {
+  if (m_track_type == TrackType::Drums) {
         return;
     }
 


### PR DESCRIPTION
Currently CHOpt has FNF notes not counting chords properly, this is because it considers chords split notes since the actual game allows you to hit the individual notes in chords separately on non-pro instruments.

This leads to the path notation to be really hard to follow across all instruments. Removing the split note check for Festival fixes this issue.